### PR TITLE
Include a metrical_shape column in the CSV.

### DIFF
--- a/src/sedes.py
+++ b/src/sedes.py
@@ -3,18 +3,23 @@ import re
 def assign(scansion):
     """From a metrical scansion (sequence of (character cluster, preliminary
     metrical analysis, final metrical analysis) tuples as output by
-    hexameter.scan.analyze_line_metrical), produce a sequence of (word, sedes)
-    tuples."""
+    hexameter.scan.analyze_line_metrical), produce a sequence of (word, sedes,
+    shape) tuples."""
     # Output list of tuples.
     result = []
     # List of character cluster making up the current word.
     word = []
+    # List of "-" and "+" symbols indicating the metrical shape of the current
+    # word.
+    shape = []
     # Sedes of the current word -- the first sedes seen after a word break.
     word_sedes = None
     # Buffer of words seen up until a sedes after a word break. This is needed
     # for sequences like "δ’ ἐτελείετο", where the "δ’" inherits the sedes of
     # the following word.
     words = []
+    # Buffer of metrical shapes seen up until a sedes after a word break.
+    shapes = []
     sedes = 0.0
 
     # Append a dummy word break at the end of the line, as a sentinel to output
@@ -24,6 +29,8 @@ def assign(scansion):
 
     for c, _, value in scansion:
         word.append(c)
+        if value in ("-", "+"):
+            shape.append(value)
         if " " in c:
             assert value == "", value
             assert word, word
@@ -33,13 +40,17 @@ def assign(scansion):
             word = re.sub("^[^\\w\u0313\u0314\u0301\u0342\u0300\u0308\u0345\u0323\u2019]*", "", word)
             word = re.sub("[^\\w\u0313\u0314\u0301\u0342\u0300\u0308\u0345\u0323\u2019]*$", "", word)
             words.append(word)
+            shape = "".join(shape)
+            shapes.append(shape)
             if word_sedes is not None:
                 # Once we know the sedes, output all the words seen since the
                 # last time we saw a sedes.
-                for w in words:
-                    result.append((w, "{:g}".format(word_sedes)))
+                for (w, s) in zip(words, shapes):
+                    result.append((w, "{:g}".format(word_sedes), s))
                 words = []
+                shapes = []
             word = []
+            shape = []
             word_sedes = None
 
         # If it's a vowel with a sedes value, advance the sedes counter.

--- a/src/tei2csv
+++ b/src/tei2csv
@@ -34,17 +34,17 @@ def assign_sedes_for_line(line):
     sedes will be non-blank if and only if num_scansions is equal to 1."""
     scansions = hexameter.scan.analyze_line_metrical(line)
     if len(scansions) == 1:
-        return tuple((word, sedes, len(scansions)) for (word, sedes) in sedes.assign(scansions[0]))
+        return tuple((word, sedes, shape, len(scansions)) for (word, sedes, shape) in sedes.assign(scansions[0]))
     else:
         # If no scansions or multiple scansions, output "".
-        return tuple((word, "", len(scansions)) for word in extract_words(line))
+        return tuple((word, "", "", len(scansions)) for word in extract_words(line))
 
 def process(f):
     global csv_w, work_identifier
     doc = tei.TEI(f)
     for line in doc.lines():
         for word_n, entry in enumerate(assign_sedes_for_line(line.text)):
-            word, sedes, num_scansions = entry
+            word, sedes, shape, num_scansions = entry
             csv_w.writerow({
                 "work": work_identifier,
                 "book_n": line.book_n,
@@ -53,6 +53,7 @@ def process(f):
                 "word": word,
                 "num_scansions": num_scansions,
                 "sedes": sedes,
+                "metrical_shape": shape,
             })
 
 opts, args = getopt.gnu_getopt(sys.argv[1:], "h", ["help"])
@@ -71,7 +72,7 @@ except ValueError:
 
 csv_w = csv.DictWriter(
     sys.stdout,
-    ["work", "book_n", "line_n", "word_n", "word", "num_scansions", "sedes"],
+    ["work", "book_n", "line_n", "word_n", "word", "num_scansions", "sedes", "metrical_shape"],
     lineterminator="\n",
 )
 csv_w.writeheader()


### PR DESCRIPTION
Closes #1 

It looks like this:
```
work,book_n,line_n,word_n,word,num_scansions,sedes,metrical_shape
Il.,1,1,1,μῆνιν,1,1,+-
Il.,1,1,2,ἄειδε,1,2,-+-
Il.,1,1,3,θεὰ,1,4,-+
Il.,1,1,4,πηληϊάδεω,1,6,++--+
Il.,1,1,5,ἀχιλῆος,1,9.5,--++
...
Il.,1,8,1,τίς,1,1,+
Il.,1,8,2,τ’,1,2,
Il.,1,8,3,ἄρ,1,2,+
Il.,1,8,4,σφωε,1,3,+-
Il.,1,8,5,θεῶν,1,4,-+
Il.,1,8,6,ἔριδι,1,5.5,--+
Il.,1,8,7,ξυνέηκε,1,7.5,--+-
Il.,1,8,8,μάχεσθαι,1,10,-++
...
Il.,1,59,1,ἀτρεί̈δη,1,1,+--+
Il.,1,59,2,νῦν,1,4,+
Il.,1,59,3,ἄμμε,1,5,+-
Il.,1,59,4,παλιμπλαγχθέντας,1,6,-+++-
Il.,1,59,5,ὀί̈ω,1,10,-++
```

Lines with uncertain scansion (`num_scansions`>2) omit the shape, just as they omit the sedes.
```
Il.,1,3,1,πολλὰς,2,,
Il.,1,3,2,δ’,2,,
Il.,1,3,3,ἰφθίμους,2,,
Il.,1,3,4,ψυχὰς,2,,
Il.,1,3,5,Ἄϊδι,2,,
Il.,1,3,6,προί̈αψεν,2,,
```