### PR TITLE
Textfixes

### DIFF
--- a/corpus/argonautica.xml
+++ b/corpus/argonautica.xml
@@ -2623,7 +2623,7 @@
                 <lb />tou\s d' a)/mudis kraterw=| su\n dou/rati ku/matos o(rmh\
                 <lb />ui(h=as *fri/coio met' h)io/nas ba/le nh/sou
                 <lb rend="displayNum" n="1120" />nu/xq' u(/po lugai/hn: to\ de\ muri/on e)k *dio\s u(/dwr
-                <lb />lh=cen a(/m' h)eli/w:| ta/xa d' e)ggu/qen a)ntebo/lhsan
+                <lb />lh=cen a(/m' h)eli/w|: ta/xa d' e)ggu/qen a)ntebo/lhsan
                 <lb />a)llh/lois, *)/argos de\ paroi/tatos e)/kfato mu=qon:
 <milestone n="1125" unit="card" />
                 <lb rend="displayNumAndIndent" /><q direct="unspecified">*)anto/meqa pro\s *zhno\s *)epoyi/ou, oi(/tine/s e)ste


### PR DESCRIPTION
Fixed argon 2.1121: iota subscript and Greek middle dot were out of sequence.