### PR TITLE
Replace arctan with a logistic function in shade mapping.

### DIFF
--- a/src/tei2html
+++ b/src/tei2html
@@ -77,7 +77,8 @@ def esc(v):
     return html.escape(v, True)
 
 def tone_map(z):
-    return 0.5 + math.atan(z * SHADE_MAPPING_ADJUST) / math.pi
+    # Logistic function.
+    return 1.0 / (1.0 + math.exp(-z * SHADE_MAPPING_ADJUST))
 
 def z_css(z):
     if z is None:


### PR DESCRIPTION
The HTML visualization uses a [tone mapping](https://en.wikipedia.org/wiki/Tone_mapping) operation to map the infinite interval (−∞, +∞) to the finite interval (0, 1). Currently we do this with the arctangent function. This branch changes it to use the logistic function instead. Compared to the arctangent, the logistic function is a bit less steep near the center, but approaches the extreme values more quickly. You can compare the two options at https://www.desmos.com/calculator/y7uem2onj1; the *s* parameter corresponds to the `--shade-mapping-adjust` option of `tei2html`.

Visual comparison of how the tone mapping operations affect the shading gradient.

Arctangent:
![arctan](https://user-images.githubusercontent.com/53617134/93515218-c9987f80-f917-11ea-9007-49c41600fbda.png)
Logistic:
![logistic](https://user-images.githubusercontent.com/53617134/93515232-cef5ca00-f917-11ea-86f1-a6a51c0e1ab6.png)

Actangent:
![arctan, diverging](https://user-images.githubusercontent.com/53617134/93515230-cd2c0680-f917-11ea-9644-d99f4c7dcde4.png)
Logistic:
![logistic, diverging](https://user-images.githubusercontent.com/53617134/93515235-d026f700-f917-11ea-99f0-bd621608c443.png)
