### PR TITLE
Update for CLTK 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,19 @@ in a virtual environment:
 ```
 python3 -m venv venv
 source venv/bin/activate
+pip3 install -U pip setuptools wheel
 pip3 install cltk bs4 lxml
 ```
 
-Next, [install the `greek_models_cltk` corpus](https://docs.cltk.org/en/latest/importing_corpora.html):
+Next, [install the `grc_models_cltk` corpus](https://docs.cltk.org/en/latest/data.html):
 ```
-python3 -c 'from cltk.corpus.utils.importer import CorpusImporter; CorpusImporter("greek").import_corpus("greek_models_cltk")'
+python3 -c 'from cltk.data.fetch import FetchCorpus; FetchCorpus("grc").import_corpus("grc_models_cltk")'
 ```
 
 The corpus is stored in a `cltk_data` subdirectory of your home directory.
 The authors have used commit
-[a68b9837](https://github.com/cltk/grc_models_cltk/commit/a68b983734d34df16fd49661f11c4ea037ab173a)
-of the `greek_models_cltk` corpus.
+[94c04ac](https://github.com/cltk/grc_models_cltk/commit/94c04acac4405e264322d825978a2f2a80d01da5)
+of the `grc_models_cltk` corpus.
 
 You only need to do the steps above once.
 Thereafter, every time you start a new shell,

--- a/src/lemma.py
+++ b/src/lemma.py
@@ -1,19 +1,17 @@
 # Lemmatization for Greek.
 #
-# Requires CLTK and the greek_models_cltk corpus. See:
+# Requires CLTK and the grc_models_cltk corpus. See:
 #   https://docs.cltk.org/en/latest/installation.html
-#   https://docs.cltk.org/en/latest/importing_corpora.html
-# python3 -c 'from cltk.corpus.utils.importer import CorpusImporter; CorpusImporter("greek").import_corpus("greek_models_cltk")'
+#   https://docs.cltk.org/en/latest/data.html
+# python3 -c 'from cltk.data.fetch import FetchCorpus; FetchCorpus("grc").import_corpus("grc_models_cltk")'
 
 import re
 import unicodedata
 
 try:
-    # https://docs.cltk.org/en/latest/greek.html#lemmatization-backoff-method
-    from cltk.lemmatize.greek.backoff import BackoffGreekLemmatizer
+    from cltk.lemmatize.grc import GreekBackoffLemmatizer
     from cltk.lemmatize.backoff import DictLemmatizer
-    # https://docs.cltk.org/en/latest/greek.html#normalization
-    from cltk.corpus.utils.formatter import cltk_normalize
+    from cltk.alphabet.text_normalization import cltk_normalize
 except ModuleNotFoundError as e:
     e.msg += ". Run:\nsource venv/bin/activate"
     raise
@@ -266,7 +264,7 @@ def pre_transformations(word):
 # is responsible for the returned result. We want to ignore lemmata that come
 # from IdentityLemmatizer in the lookup loop below, because a returned identity
 # lemma would otherwise prevent us from trying the next pre-transformation.
-cltk_lemmatizer = BackoffGreekLemmatizer(verbose = True)
+cltk_lemmatizer = GreekBackoffLemmatizer(verbose = True)
 # Insert our own lookup of hardcoded lemmata before the CTLK process.
 lemmatizer = DictLemmatizer(dict(
     (map(cltk_normalize, x) for x in OVERRIDES)


### PR DESCRIPTION
These are the source code changes needed to use CLTK 1.0. However, the change results in a lot of changes to lemmata that need to be looked at before merging.

Here is how to clone a temporary repo using the cltkv1 branch:
```
git clone -b cltkv1 https://github.com/sasansom/sedes sedes-cltkv1
cd sedes-cltkv1
python3 -m venv venv
source venv/bin/activate
pip3 install -U pip setuptools wheel
pip3 install cltk bs4 lxml
```

Sadly, this installation process downloads a *lot* more data than the former version did. I'm not sure why—maybe the new version requirements are newer than exist in the system Python installation.
```
$ du -sh sedes/venv sedes-cltkv1/venv
61M     sedes/venv
2.0G    sedes-cltkv1/venv
```

Now install the Greek language model. There's actually no need to remove the ~/cltk_data directory first, because the model's name has changed (from greek_models_cltk to grc_models_cltk).
```
python3 -c 'from cltk.data.fetch import FetchCorpus; FetchCorpus("grc").import_corpus("grc_models_cltk")'
```

The size of the language model is about the same:
```
$ du -sh ~/cltk_data/*/model/*
220M    $HOME/cltk_data/grc/model/grc_models_cltk
220M    $HOME/cltk_data/greek/model/greek_models_cltk
```

Run the SEDES pipeline as usual:
```
make -j4
```

Here's the part that needs input.
```
cd ..
diff -ru sedes/corpus sedes-cltkv1/corpus | less
```

The above command will show all the lemmata that have changed. For example, ἀγορή→ἀγορά:
```
-Phaen.,1,3,4,ἀγοραί,ἀγορή,6,⏑⏑–,auto,1
+Phaen.,1,3,4,ἀγοραί,ἀγορά,6,⏑⏑–,auto,1
```

You can also look at the differences in the raw expectancy values. There are a number of new and removed lemmata:
```
diff -ru sedes/expectancy.all.csv sedes-cltkv1/expectancy.all.csv | less
```

It looks like about 2% of words have a changed lemma:
```
$ diff -ru sedes/corpus sedes-cltkv1/corpus | diffstat -s
 12 files changed, 10909 insertions(+), 10909 deletions(-)
$ wc -l sedes/corpus/*.csv | tail -1
  489390 total                    
```