### PR TITLE
Generalized expectancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,56 @@ same commands as `make` would:
 ```
 
 
+## Controlling the variables used to calculate expectancy
+
+You can control what variables are used to group the input
+for expectancy calculation using the
+`--by` command-line option of the expectancy and tei2html programs.
+By default the programs compute the *sedes* expectancy of each distinct lemma,
+as if you had used `--by sedes/lemma`.
+
+The syntax of the `--by` option is
+<code><var>dist_vars</var>/<var>cond_vars</var></code>,
+with "distribution variables" on the left of the slash and
+"condition variables" on the right.
+On either side of the slash, there may be zero or more variable names,
+separated by commas.
+To calculate expectancy, the programs first partition the input
+into groups according to distinct values of the condition variables.
+Then, they find the expectancy of each of the distinct values
+of the distribution variables.
+
+For example, by default, the programs first divide the input
+into groups, where each group represents one distinct lemma.
+Then, within each lemma group, they find what *sedes*
+are more and less expected.
+
+To use variables other than the default,
+you will have to run the component programs manually,
+rather than using `make`.
+
+This is an example of calculating *sedes* expectancy
+after first grouping by metrical shape, rather than lemma:
+```
+src/expectancy --by sedes/metrical_shape corpus/*.csv > expectancy.sedes-metrical_shape.csv
+src/tei2html --by sedes/metrical_shape corpus/aratus.xml expectancy.sedes-metrical_shape.csv > aratus.sedes-metrical_shape.html
+```
+
+If you want a summary of the expectancy of a single variable
+across the entire input, without any grouping at all,
+you can do that too.
+For example, to count the number of occurrences of each unique word:
+```
+src/expectancy --by word/ corpus/*.csv
+```
+
+Or to calculate the overall *sedes* expectancy,
+without first grouping by lemma or any other variable:
+```
+src/expectancy --by sedes/ corpus/*.csv
+```
+
+
 ## Data format
 
 The output of `tei2csv` is

--- a/src/common.py
+++ b/src/common.py
@@ -1,0 +1,50 @@
+# Parse a dist/cond variables specification. The syntax is a comma-separated
+# list of dist_vars, optionally followed by a slash and a comma-separated list
+# of cond_vars. A backslash escapes the character that follows it.
+def parse_dist_cond_vars_spec(spec):
+    dist_vars = []
+    cond_vars = []
+
+    escaped = False
+    current_vars = dist_vars
+    var = []
+    i = iter(spec)
+    while True:
+        try:
+            c = next(i)
+        except StopIteration:
+            c = None
+
+        if escaped:
+            # Previous character was a backslash, add this one verbatim.
+            if c is None:
+                raise ValueError("End of string after {!r}".format("\\"))
+            var.append(c)
+            escaped = False
+        elif c == "\\":
+            # Read the next character verbatim.
+            escaped = True
+        elif c == "/" or c == "," or c is None:
+            # Slash, comma, or end of string marks the end of a variable.
+            if var:
+                current_vars.append("".join(var))
+            else:
+                if c == "," or current_vars:
+                    raise ValueError(f"Empty variable name")
+            var.clear()
+
+            if c == "/":
+                # At the first slash, switch from dist_vars to cond_vars.
+                if current_vars is dist_vars:
+                    current_vars = cond_vars
+                else:
+                    raise ValueError(f"More than one {'/'!r}")
+            elif c is None:
+                # This is also the end of the string, so return.
+                break
+        else:
+            # Not a special character. Add it to the current variable name.
+            var.append(c)
+
+    assert not var, var
+    return tuple(dist_vars), tuple(cond_vars)

--- a/src/common.py
+++ b/src/common.py
@@ -1,5 +1,10 @@
 import re
 
+# Various programs use this as the default specification of distribution
+# variables and condition variables for the purpose of grouping for expectancy
+# computation.
+DEFAULT_DIST_COND_VARS_SPEC = "sedes/lemma"
+
 # Parse a dist/cond variables specification. The syntax is a comma-separated
 # list of dist_vars, optionally followed by a slash and a comma-separated list
 # of cond_vars. A backslash escapes the character that follows it.

--- a/src/common.py
+++ b/src/common.py
@@ -1,3 +1,5 @@
+import re
+
 # Parse a dist/cond variables specification. The syntax is a comma-separated
 # list of dist_vars, optionally followed by a slash and a comma-separated list
 # of cond_vars. A backslash escapes the character that follows it.
@@ -48,3 +50,14 @@ def parse_dist_cond_vars_spec(spec):
 
     assert not var, var
     return tuple(dist_vars), tuple(cond_vars)
+
+_ESCAPE_RE = re.compile(r"[,/\\]")
+def _escape(x):
+    return _ESCAPE_RE.sub(lambda m: f"\\{m.group()}", x)
+
+# Serialize dist_vars and cond_vars lists into the comma- and slash-delimited
+# form.
+def format_dist_cond_vars_spec(dist_vars, cond_vars):
+    return ",".join(_escape(x) for x in dist_vars) + \
+        "/" + \
+        ",".join(_escape(x) for x in cond_vars)

--- a/src/expectancy
+++ b/src/expectancy
@@ -15,30 +15,6 @@ import getopt
 import math
 import sys
 
-# We're deliberately not using modules outside the standard library, like numpy
-# or pandas, in order to make the program easier to run (see
-# https://github.com/sasansom/sedes/issues/24). This program is a translation to
-# Python of the following R program:
-#
-#   library(data.table)
-#
-#   sd_pop <- function(x) {
-#       sd(x) * sqrt((length(x) - 1) / length(x))
-#   }
-#
-#   data <- data.table()
-#   for (csv_filename in commandArgs(trailingOnly=TRUE)) {
-#       data <- rbind(data, fread(csv_filename, na.strings=c("")))
-#   }
-#
-#   data[is.na(lemma), lemma := word]
-#
-#   data <- data[, .(x = .N), by = .(lemma, sedes)]
-#   data[, z := (x - mean(rep(x, x))) / sd_pop(rep(x, x)), by = .(lemma)]
-#
-#   setkey(data, "lemma", "sedes")
-#   write.csv(data, "", row.names=FALSE)
-
 def usage(file=sys.stdout):
     print(f"""\
 Usage: {sys.argv[0]} [INPUT.csv...] > OUTPUT.csv

--- a/src/expectancy
+++ b/src/expectancy
@@ -66,6 +66,13 @@ def group_by(x, *fieldnames):
         j += 1
     yield key, x[i:]
 
+def unique(a):
+    result = []
+    for x in a:
+        if x not in result:
+            result.append(x)
+    return tuple(result)
+
 # Special treatment for certain columns with certain names before writing to
 # CSV.
 OUTPUT_TRANSFORMS = {
@@ -75,23 +82,29 @@ OUTPUT_TRANSFORMS = {
     "z": lambda val: "{:+.15g}".format(val),
 }
 
-# Has the side effect of sorting input by lemma and sedes.
-def process(input, output):
+# Has the side effect of sorting input by the variables in
+# cond_vars + dist_vars.
+def process(input, output, cond_vars, dist_vars):
     expectancy = []
 
-    # The sedes may be None, so add a None-checking element to the key, to avoid
-    # an error caused by trying to compare None and a float.
-    input.sort(key = lambda row: (row["lemma"], row["sedes"] is not None, row["sedes"]))
+    # Sort input so elements that are identical in cond_vars + dist_vars are
+    # contiguous.
+    #
+    # Values (in particular sedes) may be None, so add a None-checking guard
+    # before each one, in order to avoid comparing NoneType to float, for
+    # example.
+    input.sort(key = lambda row:
+        tuple(x for v in cond_vars + dist_vars for x in (row[v] is not None, row[v]))
+    )
 
-    # Count the unique lemma/sedes pairs.
-    for (lemma, sedes), group in group_by(input, "lemma", "sedes"):
-        expectancy.append({
-            "lemma": lemma,
-            "sedes": sedes,
-            "x": len(group),
-        })
+    # Count unique cond_vars+dist_vars tuples.
+    for vals, group in group_by(input, *unique(cond_vars + dist_vars)):
+        expectancy.append(dict(
+            zip(unique(cond_vars + dist_vars), vals),
+            x = len(group),
+        ))
 
-    for (lemma,), group in group_by(expectancy, "lemma"):
+    for _, group in group_by(expectancy, *cond_vars):
         xvec = [inst["x"] for inst in group]
         μ = weighted_mean(xvec)
         σ = weighted_sd_pop(xvec)
@@ -107,12 +120,10 @@ def process(input, output):
             if f is not None:
                 row[k] = f(row[k])
 
-    output = csv.DictWriter(output, [
-        "lemma",
-        "sedes",
+    output = csv.DictWriter(output, unique(cond_vars + dist_vars) + (
         "x",
         "z",
-    ], lineterminator="\n")
+    ), lineterminator="\n")
     output.writeheader()
     output.writerows(expectancy)
 
@@ -128,7 +139,7 @@ def main():
         with open(filename) as f:
             input.extend(read_input(f))
 
-    process(input, sys.stdout)
+    process(input, sys.stdout, ("lemma",), ("sedes",))
 
 if __name__ == "__main__":
     main()

--- a/src/expectancy
+++ b/src/expectancy
@@ -1,12 +1,37 @@
 #!/usr/bin/env python3
 
-# Computes an expectancy score for each unique lemma/sedes pair in the input
-# files, as produced by tei2csv.
+# Computes expectancy z-scores for unique values of grouping variables in input
+# produced by tei2csv.
 #
 # Usage:
 #   expectancy corpus/*.csv > expectancy.csv
 #
-# Writes CSV to standard output. Besides lemma and sedes, there are two columns:
+# Expectancy is computed relative to two sets of grouping variables: The
+# "distribution variables" and the "condition variables". The input is first
+# partitioned into separate subsets according to distinct values of the
+# condition variables. Then, within each subset, expectancy is computed
+# according to the counts of distinct values of the distribution variables.
+#
+# You can control the condition variables and distribution variables with the
+# --by option. The default value of the option is "sedes/lemma". The format is
+# a comma-separated list of distribution variables on the left, then a slash
+# character, then a comma-separated list of condition variables on the right.
+# Use a backslash to escape commas, slashes, and backslashes in variable names.
+#
+# This command line is equivalent to the default:
+#   expectancy --by sedes/lemma corpus/*.csv
+# This command will get the expectancy of lemmata within each book of each work:
+#   expectancy --by lemma/work,book_n corpus/*.csv
+# The list of variables before or after the slash may be empty, which means that
+# every input row should be considered equivalent according to that set. If the
+# slash is omitted, it means the list of condition variables is empty. For
+# example, these two equivalent commands get the overall sedes expectancy,
+# without first partitioning by lemma or any other variable:
+#   expectancy --by sedes/ corpus/*.csv
+#   expectancy --by sedes corpus/*.csv
+#
+# Writes CSV to standard output. The columns are the names of the grouping
+# variables, plus two more:
 #   x: The number of times this lemma/sedes pair appears
 #   z: The expectancy score, weighted as if each x value were repeated x times.
 
@@ -15,12 +40,31 @@ import getopt
 import math
 import sys
 
+import common
+
 def usage(file=sys.stdout):
     print(f"""\
-Usage: {sys.argv[0]} [INPUT.csv...] > OUTPUT.csv
+Usage: {sys.argv[0]} [OPTIONS...] [INPUT.csv...] > OUTPUT.csv
 
-Computes expectancy z-scores for every unique lemma/sedes pair found in
-the corpus of INPUT.csv files. The INPUT.csv files are the output of tei2csv.
+Computes expectancy z-scores for unique values of grouping variables
+(by default lemma and sedes) found in the corpus of INPUT.csv files.
+The INPUT.csv files are the output of tei2csv.
+
+Use the --by option to control the variables according to which
+expectancy is computed. The default value of --by is "sedes/lemma". The
+syntax is a comma-separated list of "distribution variables" on the
+left, then a slash, then a comma-separated list of "condition variables"
+on the right. Use a backslash to escape commas, slashes, and backslashes
+in variable names.
+
+The input is first partitioned into groups according to unique values of
+the condition variables. Then, within each group, expectancy is computed
+according to distinct values of the distribution variables.
+
+  --by DIST_VARS.../COND_VARS...
+              Set the grouping variables according to which expectancy
+              is computed. Default: "sedes/lemma".
+  -h, --help  Show this help.
 """, end="", file=file)
 
 # Return the mean of the sequence that arises from repeating each element e of
@@ -83,11 +127,11 @@ OUTPUT_TRANSFORMS = {
 }
 
 # Has the side effect of sorting input by the variables in
-# cond_vars + dist_vars.
-def process(input, output, cond_vars, dist_vars):
+# dist_vars + cond_vars.
+def process(input, output, dist_vars, cond_vars):
     expectancy = []
 
-    # Sort input so elements that are identical in cond_vars + dist_vars are
+    # Sort input so elements that are identical in cond_vars+dist_vars are
     # contiguous.
     #
     # Values (in particular sedes) may be None, so add a None-checking guard
@@ -128,18 +172,32 @@ def process(input, output, cond_vars, dist_vars):
     output.writerows(expectancy)
 
 def main():
-    opts, filenames = getopt.gnu_getopt(sys.argv[1:], "h", ["help"])
-    for o, _ in opts:
-        if o in ("-h", "--help"):
+    # Default grouping variables if not specified with --by.
+    dist_cond_vars_spec = "sedes/lemma"
+
+    opts, filenames = getopt.gnu_getopt(sys.argv[1:], "h", (
+        "by=",
+        "help",
+    ))
+    for o, a in opts:
+        if o == "--by":
+            dist_cond_vars_spec = a
+        elif o in ("-h", "--help"):
             usage()
             sys.exit(0)
+
+    try:
+        dist_vars, cond_vars = common.parse_dist_cond_vars_spec(dist_cond_vars_spec)
+    except ValueError as e:
+        print(f"error parsing --by specification {dist_cond_vars_spec!r}: {e}")
+        sys.exit(1)
 
     input = []
     for filename in filenames:
         with open(filename) as f:
             input.extend(read_input(f))
 
-    process(input, sys.stdout, ("lemma",), ("sedes",))
+    process(input, sys.stdout, dist_vars, cond_vars)
 
 if __name__ == "__main__":
     main()

--- a/src/expectancy
+++ b/src/expectancy
@@ -173,7 +173,7 @@ def process(input, output, dist_vars, cond_vars):
 
 def main():
     # Default grouping variables if not specified with --by.
-    dist_cond_vars_spec = "sedes/lemma"
+    dist_cond_vars_spec = common.DEFAULT_DIST_COND_VARS_SPEC
 
     opts, filenames = getopt.gnu_getopt(sys.argv[1:], "h", (
         "by=",

--- a/src/join-expectancy
+++ b/src/join-expectancy
@@ -3,12 +3,23 @@
 # Usage:
 #   join-expectancy corpus/work.csv expectancy.all.csv > joined.csv
 #
-# Outputs work.csv, augmented with rows from expectancy.all.csv that match in
-# the "lemma" and "sedes" columns (left outer join).
+# Outputs work.csv, augmented with rows from expectancy.all.csv (left outer
+# join) that match in certain columns ("lemma" and "sedes" by default).
+#
+# The --by option controls the grouping variables. The format is a
+# comma-separated list of variable names. You may also use up to one slash
+# character between variable names, in order to match the --by syntax understood
+# by other programs (though this program makes no distinction between the
+# "distribution" variables on the left and the "condition" variables on the
+# right). Use a backslash to escape commas, slashes, and backslashes in variable
+# names. Example:
+#   join-expectancy --by sedes,lemma corpus/work.csv expectancy.all.csv > joined.csv
 
 import csv
 import getopt
 import sys
+
+import common
 
 def usage(file = sys.stdout):
     print(f"""\
@@ -17,8 +28,6 @@ Usage: {sys.argv[0]} WORK.CSV [WORK.CSV...] EXPECTANCY.CSV > JOINED.CSV
 Outputs the contents of the WORK.CSV inputs, augmented with the rows from
 EXPECTANCY.CSV that match on the "lemma" and "sedes" columns.
 """, end="", file=file)
-
-COMMON_FIELDS = ("lemma", "sedes")
 
 def unique(s):
     result = []
@@ -72,11 +81,26 @@ def join(left, right_file, fieldnames, output):
                 output.writerow({**row, **match})
 
 def main():
-    opts, args = getopt.gnu_getopt(sys.argv[1:], "h", ["help"])
-    for o, _ in opts:
-        if o in ("-h", "--help"):
+    # Default common variables if not specified with --by.
+    common_vars_spec = "sedes/lemma"
+
+    opts, args = getopt.gnu_getopt(sys.argv[1:], "h", (
+        "by=",
+        "help",
+    ))
+    for o, a in opts:
+        if o == "--by":
+            common_vars_spec = a
+        elif o in ("-h", "--help"):
             usage()
             sys.exit(0)
+
+    try:
+        dist_vars, cond_vars = common.parse_dist_cond_vars_spec(common_vars_spec)
+    except ValueError as e:
+        print(f"error parsing --by specification {common_vars_spec!r}: {e}")
+        sys.exit(1)
+    common_vars = unique(dist_vars + cond_vars)
 
     try:
         (*work_filenames, expectancy_filename) = args
@@ -88,7 +112,7 @@ def main():
         sys.exit(1)
     works = MultiDictReader(work_filenames)
     with open(expectancy_filename) as expectancy:
-        join(works, expectancy, COMMON_FIELDS, sys.stdout)
+        join(works, expectancy, common_vars, sys.stdout)
 
 if __name__ == "__main__":
     main()

--- a/src/join-expectancy
+++ b/src/join-expectancy
@@ -82,7 +82,7 @@ def join(left, right_file, fieldnames, output):
 
 def main():
     # Default common variables if not specified with --by.
-    common_vars_spec = "sedes/lemma"
+    common_vars_spec = common.DEFAULT_DIST_COND_VARS_SPEC
 
     opts, args = getopt.gnu_getopt(sys.argv[1:], "h", (
         "by=",

--- a/src/tei2html
+++ b/src/tei2html
@@ -282,6 +282,9 @@ def process(f, expectancy, dist_vars, cond_vars):
 #sedes-dist td {
     text-align: right;
 }
+#sedes-dist caption {
+    text-align: left;
+}
 
 h1 a, h2 a {
     color: inherit;
@@ -535,6 +538,7 @@ summary, .word {
 </table>
 
 <table id=sedes-dist>
+<caption>Expectancy according to {expectancy_vars}</caption>
 <tr>
   <td></td>
   <th scope=col id=sedes-dist-header-1>1</th>
@@ -618,7 +622,13 @@ summary, .word {
 </table>
 
 </div>
-</details>""".format(min = fmt_float(SHADE_SCALE_RANGE[0]), max = fmt_float(SHADE_SCALE_RANGE[1])))
+</details>""".format(
+    min = fmt_float(SHADE_SCALE_RANGE[0]),
+    max = fmt_float(SHADE_SCALE_RANGE[1]),
+    expectancy_vars = ", ".join(f"<var>{esc(var)}</var>" for var in dist_vars) +
+                      " / " +
+                      ", ".join(f"<var>{esc(var)}</var>" for var in cond_vars),
+))
 
     print_start_tag("article")
 

--- a/src/tei2html
+++ b/src/tei2html
@@ -2,6 +2,14 @@
 
 # Usage:
 #   tei2html corpus/shield.xml expectancy.hellenic+archaic.csv > shield.html
+#
+# The --by option controls the selection of variables according to which
+# expectancy is computed. The value passed to --by must match the one that was
+# given to the expectancy program earlier. The default value of --by is
+# "sedes/lemma". The format is a comma-separated list of distribution variables
+# on the left, then a slash character, then a comma-separated list of condition
+# variables on the right. Use a backslash to escape commas, slashes, and
+# backslashes in variable names. See the expectancy program for examples.
 
 import collections
 import csv
@@ -46,8 +54,20 @@ WORK.XML is a TEI XML document containing the text of the work.
 STATS.csv is statistics on a corpus of text as produced by
 the tei2csv and expectancy programs.
 
-  -s NUM, --shade-mapping-adjust=NUM  change steepness of shade mapping
-                                      (default {SHADE_MAPPING_ADJUST:.1f})
+Use the --by option to control the variables according to which
+expectancy is computed. This must match the --by value that was provided
+to the expectancy program. The default value of --by is "sedes/lemma".
+The syntax is a comma-separated list of "distribution variables" on the
+left, then a slash, then a comma-separated list of "condition variables"
+on the right. Use a backslash to escape commas, slashes, and backslashes
+in variable names.
+
+  --by DIST_VARS.../COND_VARS...
+              set the grouping variables according to which expectancy
+                is computed (default: "sedes/lemma")
+  -s NUM, --shade-mapping-adjust=NUM
+              change steepness of shade mapping
+                (default {SHADE_MAPPING_ADJUST:.1f})
   -h, --help  show this help
 """, end="", file=file)
 
@@ -760,11 +780,8 @@ summary, .word {
             # are usable in dist_vars and cond_vars lookups.
             VAR_VALUES = {
                 # We don't actually know the work_id of the text we are
-                # processing--but it doesn't matter, because this program
-                # currently processes just one work at a time. We can use any
-                # value here that compares equal to itself.
-                "work": "work",
-
+                # processing, so we cannot use work as a grouping variable.
+                # "work": None,
                 "book_n": loc.book_n,
                 "line_n": loc.line_n,
                 "word_n": word_n,
@@ -895,16 +912,17 @@ function info(target) {
     // These are the variables whose values we know how to produce and are
     // usable in DIST_VARS and COND_VARS lookups.
     const VAR_VALUES = new Map([
-        // We don't actually know the work_id of the text we are processing--but
-        // it doesn't matter, because this program currently processes just one
-        // work at a time. We can use any value here that compares equal to
-        // itself.
-        ["work", "work"],
-
+        // We don't actually know the work_id of the text we are processing, so
+        // we cannot use work as a grouping variable.
+        // ["work", null],
         ["book_n", bookno],
         ["line_n", lineno],
         ["word_n", wordno],
-        ["word", target.textContent],
+        // Lowercase the literal word from the text, to match what
+        // hexameter.analyze_line_metrical does internally and what is stored in
+        // tei2csv output.
+        // https://github.com/sasansom/sedes/blob/526941f65bf88efb82db7d3bfbfe632e4f0d40ff/src/hexameter/scan.py#L378
+        ["word", target.textContent.toLowerCase()],
         ["lemma", target.getAttribute("data-lemma")],
         ["sedes", target.getAttribute("data-sedes")],
         ["metrical_shape", target.getAttribute("data-shape")],
@@ -1014,16 +1032,28 @@ CONTROLS["show-undefined-expectancy"].dispatchEvent(new Event("change"));
     print("</html>")
 
 def main():
-    opts, args = getopt.gnu_getopt(sys.argv[1:], "hs:", ["help", "shade-mapping-adjust="])
+    # Default grouping variables if not specified with --by.
+    dist_cond_vars_spec = "sedes/lemma"
+
+    opts, args = getopt.gnu_getopt(sys.argv[1:], "hs:", (
+        "by=",
+        "help",
+        "shade-mapping-adjust=",
+    ))
     for o, a in opts:
-        if o in ("-h", "--help"):
+        if o == "--by":
+            dist_cond_vars_spec = a
+        elif o in ("-h", "--help"):
             usage()
             sys.exit(0)
         elif o in ("-s", "--shade-mapping-adjust"):
             SHADE_MAPPING_ADJUST = float(a)
 
-    dist_vars = ("sedes",)
-    cond_vars = ("lemma",)
+    try:
+        dist_vars, cond_vars = common.parse_dist_cond_vars_spec(dist_cond_vars_spec)
+    except ValueError as e:
+        print(f"error parsing --by specification {dist_cond_vars_spec!r}: {e}")
+        sys.exit(1)
 
     try:
         tei_filename, expectancy_filename = args

--- a/src/tei2html
+++ b/src/tei2html
@@ -1033,7 +1033,7 @@ CONTROLS["show-undefined-expectancy"].dispatchEvent(new Event("change"));
 
 def main():
     # Default grouping variables if not specified with --by.
-    dist_cond_vars_spec = "sedes/lemma"
+    dist_cond_vars_spec = common.DEFAULT_DIST_COND_VARS_SPEC
 
     opts, args = getopt.gnu_getopt(sys.argv[1:], "hs:", (
         "by=",

--- a/src/tei2html
+++ b/src/tei2html
@@ -12,6 +12,7 @@ import sys
 import re
 import unicodedata
 
+import common
 import lemma as lemma_mod
 import sedes as sedes_mod
 import tei
@@ -59,13 +60,19 @@ def float_or_none(s):
     else:
         return float(s)
 
-def parse_expectancy(f):
+# Parse an expectancy CSV file (as output by the expectancy program). dist_vars
+# and cond_vars are the columns to use as a key for looking up x and z values.
+# Returns a two-level dict whose top level maps cond_vars to another dict that
+# maps dist_vars to ExpectancyEntry.
+def parse_expectancy(f, dist_vars, cond_vars):
     stats = {}
     for row in csv.DictReader(f):
-        key = (row["lemma"], row["sedes"])
-        if key in stats:
-            raise ValueError(f"duplicate lemma/sedes pair {key}")
-        stats[key] = ExpectancyEntry(
+        dist_key = tuple(row[k] for k in dist_vars)
+        cond_key = tuple(row[k] for k in cond_vars)
+        dist_map = stats.setdefault(cond_key, {})
+        if dist_key in dist_map:
+            raise ValueError(f"duplicate {common.format_dist_cond_vars_spec(dist_vars, cond_vars)} key {(dist_key, cond_key)}")
+        dist_map[dist_key] = ExpectancyEntry(
             x = int(row["x"]),
             z = float_or_none(row["z"]),
         )
@@ -171,7 +178,7 @@ def assign_sedes_for_line(line):
     else:
         return tuple((word, None, None) for word in line.words())
 
-def process(f, expectancy):
+def process(f, expectancy, dist_vars, cond_vars):
     doc = tei.TEI(f)
 
     print(f"""\
@@ -600,15 +607,14 @@ summary, .word {
             print(esc(normalize(doc.title)), end="")
         print()
 
-    # Lemmata whose expectancy entries actually needed for the words in this
+    # Values of cond_vars whose expectancy entries we actually need for this
     # text, built up as we go.
     expectancy_needed = set()
 
-    # Sum of x per lemma.
+    # Sum of x per unique values of cond_vars.
     sum_x = {}
-    for (lemma, _), expectancy_entry in expectancy.items():
-        sum_x.setdefault(lemma, 0)
-        sum_x[lemma] += expectancy_entry.x
+    for cond_key, dist_map in expectancy.items():
+        sum_x[cond_key] = sum(expectancy_entry.x for expectancy_entry in dist_map.values())
 
     # Cache of already emitted automatically generated HTML element ids, to
     # avoid duplicated.
@@ -749,11 +755,31 @@ summary, .word {
             if sedes is not None:
                 word_attrs["data-sedes"] = sedes;
                 title_attr.append(f"sedes={sedes}")
-            expectancy_needed.add(lemma)
-            expectancy_entry = expectancy.get((lemma, sedes))
+
+            # These are the variables whose values we know how to produce and
+            # are usable in dist_vars and cond_vars lookups.
+            VAR_VALUES = {
+                # We don't actually know the work_id of the text we are
+                # processing--but it doesn't matter, because this program
+                # currently processes just one work at a time. We can use any
+                # value here that compares equal to itself.
+                "work": "work",
+
+                "book_n": loc.book_n,
+                "line_n": loc.line_n,
+                "word_n": word_n,
+                "word": word,
+                "lemma": lemma,
+                "sedes": sedes,
+                "metrical_shape": shape,
+            }
+            dist_key = tuple(VAR_VALUES[var] for var in dist_vars)
+            cond_key = tuple(VAR_VALUES[var] for var in cond_vars)
+            expectancy_needed.add(cond_key)
+            expectancy_entry = expectancy.get(cond_key, {}).get(dist_key)
             if expectancy_entry is not None:
                 title_attr.append(f"x={expectancy_entry.x}")
-                title_attr.append(f"Σx={sum_x[lemma]}")
+                title_attr.append(f"Σx={sum_x[cond_key]}")
                 word_attrs["class"] += " " + esc(z_css(expectancy_entry.z))
                 if expectancy_entry.z is not None:
                     z_fmt = f"{expectancy_entry.z:+.8}"
@@ -761,7 +787,7 @@ summary, .word {
                 else:
                     word_attrs["class"] += " undefined-expectancy"
             else:
-                print(f"warning: no expectancy score for book {loc.book_n} line {loc.line_n} word {word_n}: {word} {lemma!r}/{sedes}", file=sys.stderr)
+                print(f"warning: no expectancy score for book {loc.book_n} line {loc.line_n} word {word_n}: {common.format_dist_cond_vars_spec(dist_vars, cond_vars)} {(dist_key, cond_key)}", file=sys.stderr)
                 word_attrs["class"] += " error"
             if shape is not None:
                 word_attrs["data-shape"] = normalize(shape)
@@ -795,22 +821,32 @@ summary, .word {
     print("<script defer>")
     print("\"use strict\";")
 
+    print("const DIST_VARS = [" + ", ".join(js_string(var) for var in dist_vars) + "];")
+    print("const COND_VARS = [" + ", ".join(js_string(var) for var in cond_vars) + "];")
+
+    escape_re = re.compile(r"[,\\]")
+    def escape(values):
+        return ",".join(normalize(escape_re.sub(lambda m: f"\\{m.group()}", x)) for x in values)
+
     print("const EXPECTANCY = new Map([");
-    for lemma, sedes in ((lemma, sedes) for lemma, sedes in expectancy.keys() if lemma in expectancy_needed):
-        expectancy_entry = expectancy.get((lemma, sedes))
-        fields = [("x", str(expectancy_entry.x)),]
-        if expectancy_entry.z is not None:
-            fields.append(("z", f"{expectancy_entry.z:+.8}"))
-        key = f"{normalize(lemma)}/{sedes}"
-        value = ", ".join(f"{name}: {value}" for name, value in fields)
-        print(f"[{js_string(key)}, {{{value}}}],")
+    for cond_key in sorted(expectancy.keys()):
+        if cond_key not in expectancy_needed:
+            continue
+        dist_map = expectancy[cond_key]
+        print(f"[{js_string(escape(cond_key))}, new Map([")
+        for dist_key in sorted(dist_map.keys()):
+            expectancy_entry = dist_map[dist_key]
+            fields = [("x", str(expectancy_entry.x)),]
+            if expectancy_entry.z is not None:
+                fields.append(("z", f"{expectancy_entry.z:+.8}"))
+            value = ", ".join(f"{name}: {value}" for name, value in fields)
+            print(f"  [{js_string(escape(dist_key))}, {{{value}}}],")
+        print("])],")
     print("]);");
 
     print(f"const SHADE_MAPPING_ADJUST = {SHADE_MAPPING_ADJUST};")
 
     print("""
-const POSSIBLE_SEDES = [1, 2, 2.5, 3, 4, 4.5, 5, 6, 6.5, 7, 8, 8.5, 9, 10, 10.5, 11, 12].map(sedes => sedes.toString());
-
 const LOC_OUTPUT = document.getElementById("loc-output");
 const LINK_OUTPUT = document.getElementById("link-output");
 const WORD_OUTPUT = document.getElementById("word-output");
@@ -828,6 +864,13 @@ function format_signed_float(x, digits) {
 // name.
 function tone_map(z) {
     return 1.0 / (1.0 + Math.exp(-z * SHADE_MAPPING_ADJUST))
+}
+
+// Backslash-escape commas every element in values, then join the escaped
+// strings with a comma as separator. This function provides a way of using
+// arrays of strings as Map keys.
+function escape(values) {
+    return values.map(x => x.replace(/[,\\\\]/, m => "\\\\"+m)).join(",");
 }
 
 function info(target) {
@@ -849,23 +892,58 @@ function info(target) {
     LINK_OUTPUT.href = "#" + target.id;
     LINK_OUTPUT.textContent = "link";
 
-    let lemma = target.getAttribute("data-lemma");
-    let sedes = target.getAttribute("data-sedes");
-    let sum_x = POSSIBLE_SEDES.map(sedes => EXPECTANCY.get(`${lemma}/${sedes}`)?.x ?? 0).reduce((a, b) => a + b);
+    // These are the variables whose values we know how to produce and are
+    // usable in DIST_VARS and COND_VARS lookups.
+    const VAR_VALUES = new Map([
+        // We don't actually know the work_id of the text we are processing--but
+        // it doesn't matter, because this program currently processes just one
+        // work at a time. We can use any value here that compares equal to
+        // itself.
+        ["work", "work"],
 
-    WORD_OUTPUT.textContent = target.textContent;
-    SHAPE_OUTPUT.textContent = target.getAttribute("data-shape") ?? "";
-    SEDES_OUTPUT.textContent = sedes ?? "";
-    LEMMA_OUTPUT.textContent = lemma ?? "";
+        ["book_n", bookno],
+        ["line_n", lineno],
+        ["word_n", wordno],
+        ["word", target.textContent],
+        ["lemma", target.getAttribute("data-lemma")],
+        ["sedes", target.getAttribute("data-sedes")],
+        ["metrical_shape", target.getAttribute("data-shape")],
+    ]);
+
+    const dist_key = DIST_VARS.map(x => VAR_VALUES.get(x));
+    const cond_key = COND_VARS.map(x => VAR_VALUES.get(x));
+    let sum_x = 0;
+    for (const entry of EXPECTANCY.get(escape(cond_key))?.values())
+        sum_x += entry.x;
+
+    WORD_OUTPUT.textContent = VAR_VALUES.get("word");
+    SHAPE_OUTPUT.textContent = VAR_VALUES.get("metrical_shape") ?? "";
+    SEDES_OUTPUT.textContent = VAR_VALUES.get("sedes") ?? "";
+    LEMMA_OUTPUT.textContent = VAR_VALUES.get("lemma") ?? "";
     SUMX_OUTPUT.textContent = sum_x ?? "";
 
     for (let elem of SEDES_DIST.getElementsByTagName("th"))
         elem.classList.toggle("selected", false);
+    let sedes = VAR_VALUES.get("sedes");
     if (sedes != null)
         document.getElementById(`sedes-dist-header-${sedes}`).classList.toggle("selected", true);
 
-    for (let sedes of POSSIBLE_SEDES) {
-        let {x, z} = EXPECTANCY.get(`${lemma}/${sedes}`) ?? {};
+    // Fill out the sedes distribution table. This is a special case: the table
+    // does not generalize to show distributions over other variables. When
+    // dist_key and cond_key do not mention sedes, all the columns in the table
+    // will be the same.
+    const POSSIBLE_SEDES = [1, 2, 2.5, 3, 4, 4.5, 5, 6, 6.5, 7, 8, 8.5, 9, 10, 10.5, 11, 12].map(sedes => sedes.toString());
+    for (const sedes of POSSIBLE_SEDES) {
+        // Compute dist_key and cond_key as above, but override sedes with each
+        // element of POSSIBLE_SEDES in turn.
+        const dist_key = DIST_VARS.map(x => x == "sedes" ? sedes : VAR_VALUES.get(x));
+        const cond_key = COND_VARS.map(x => x == "sedes" ? sedes : VAR_VALUES.get(x));
+        let {x, z} = EXPECTANCY.get(escape(cond_key))?.get(escape(dist_key)) ?? {};
+        // Recompute sum_x for each column.
+        let sum_x = 0;
+        for (const entry of EXPECTANCY.get(escape(cond_key))?.values())
+            sum_x += entry.x;
+
         let output_x = document.getElementById(`output-x-${sedes}`);
         let output_fracx = document.getElementById(`output-fracx-${sedes}`);
         let output_z = document.getElementById(`output-z-${sedes}`);
@@ -944,6 +1022,9 @@ def main():
         elif o in ("-s", "--shade-mapping-adjust"):
             SHADE_MAPPING_ADJUST = float(a)
 
+    dist_vars = ("sedes",)
+    cond_vars = ("lemma",)
+
     try:
         tei_filename, expectancy_filename = args
     except ValueError:
@@ -953,10 +1034,10 @@ def main():
         sys.exit(1)
 
     with open(expectancy_filename) as expectancy_file:
-        expectancy = parse_expectancy(expectancy_file)
+        expectancy = parse_expectancy(expectancy_file, dist_vars, cond_vars)
 
     with open(tei_filename) as tei_file:
-        process(tei_file, expectancy)
+        process(tei_file, expectancy, dist_vars, cond_vars)
 
 if __name__ == "__main__":
     main()

--- a/src/test_common.py
+++ b/src/test_common.py
@@ -40,3 +40,20 @@ class TestParse(unittest.TestCase):
         ):
             with self.assertRaises(ValueError, msg = spec):
                 common.parse_dist_cond_vars_spec(spec)
+
+class TestRoundtrip(unittest.TestCase):
+    def test_roundtrip(self):
+        for dist_vars, cond_vars in (
+            ((), ()),
+            (("aaa",), ()),
+            ((), ("aaa",)),
+            (("aaa",), ("bbb",)),
+            (("aaa", "bbb"), ("ccc", "ddd")),
+            (("a/a,a\\a",), ()),
+        ):
+            spec = common.format_dist_cond_vars_spec(dist_vars, cond_vars)
+            try:
+                dist_vars_roundtrip, cond_vars_roundtrip = common.parse_dist_cond_vars_spec(spec)
+            except ValueError as e:
+                self.fail((dist_vars, cond_vars, spec))
+            self.assertEqual((dist_vars, cond_vars), (dist_vars_roundtrip, cond_vars_roundtrip), spec)

--- a/src/test_common.py
+++ b/src/test_common.py
@@ -1,0 +1,42 @@
+import unittest
+
+import common
+
+class TestParse(unittest.TestCase):
+    def test_parse_dist_cond_vars_spec(self):
+        for spec, expected_dist_vars, expected_cond_vars in (
+            ("", (), ()),
+            ("/", (), ()),
+            ("aaa", ("aaa",), ()),
+            ("aaa/bbb", ("aaa",), ("bbb",)),
+            ("aaa,bbb/ccc,ddd", ("aaa", "bbb"), ("ccc", "ddd")),
+            ("aaa/", ("aaa",), ()),
+            ("/aaa", (), ("aaa",)),
+            # Backslash escapes.
+            ("aaa\\,bbb/ccc", ("aaa,bbb",), ("ccc",)),
+            ("aaa\\/bbb/ccc", ("aaa/bbb",), ("ccc",)),
+            ("aaa\\\\bbb/ccc", ("aaa\\bbb",), ("ccc",)),
+            ("aaa\\abbb/ccc", ("aaaabbb",), ("ccc",)),
+        ):
+            try:
+                dist_vars, cond_vars = common.parse_dist_cond_vars_spec(spec)
+            except ValueError as e:
+                self.fail(spec)
+
+        # Inputs that should raise an exception.
+        for spec in (
+            "\\",
+            "aaa\\",
+            "aaa/\\",
+            "aaa/\\",
+            "aaa/\\",
+            "aaa,",
+            "aaa,/",
+            "aaa/,bbb",
+            "aaa/bbb,",
+            "aaa,/bbb",
+            "aaa,,bbb",
+            "aaa/bbb/ccc",
+        ):
+            with self.assertRaises(ValueError, msg = spec):
+                common.parse_dist_cond_vars_spec(spec)


### PR DESCRIPTION
Until now, the expectancy and tei2html programs have had a hardcoded assumption that they should compute expectancy according to *sedes* over lemma; that is, first break the input rows into groups according to unique lemma values, then calculate expectancy according to the distribution of *sedes* within each group ([cf.](https://digitalhumanities.org/dhq/vol/17/2/000675/000675.html#p34)).

This pull request generalizes expectancy so it may be computed according to any of the variables that tei2csv outputs (with one exception, see below). It adds a new `--by` command-line option to the expectancy, tei2html, and join-expectancy programs. The command-line usage is <code>--by <var>dist_vars</var>/<var>cond_vars</var></code>, where <code><var>cond_vars</var></code> are the variables that control grouping and <code><var>dist_vars</var></code> are the variables whose distribution is computed within each group. On either side of the slash there may be zero or more comma-separated variable names. The default remains *sedes* over lemma, as if you had used `--by sedes/lemma`.

For example, here is what `--by sedes/metrical_shape` looks like. Instead of finding the *sedes* distribution within each unique lemma, we are finding the *sedes* expectancy within each unique metrical shape (e.g. ⏑, –, – –, ⏑ – ⏑ ⏑ – ⏑, etc.). The screenshot shows that the shape – – has positive expectancy only in *sedes* 11, appearing there just over 50% the time. It is also common in *sedes* 1, at about 20%.

```
src/expectancy --by sedes/metrical_shape corpus/*.csv > expectancy.sedes-metrical_shape.csv
src/tei2html --by sedes/metrical_shape corpus/aratus.xml expectancy.sedes-metrical_shape.csv > aratus.sedes-metrical_shape.html
```

![A screenshot of tei2html output, showing the beginning of the Phaenomena, with words shaded according to sedes/metrical_shape expectancy.](https://github.com/sasansom/sedes/assets/53617134/a03c250d-dd75-4533-ba80-2a713e1bade8)

Another example shows the expectancy of just lemma and nothing else, with no preliminary grouping. This is done by putting nothing after the slash, so that <code><var>cond_vars</var></code> is empty: `--by lemma/`. (When <code><var>cond_vars</var></code> is empty, you can omit the slash, so just `--by lemma`.) Very common lemmata like δέ and καί get positive expectancy; almost all words have mildly negative expectancy.

```
src/expectancy --by lemma corpus/*.csv > expectancy.lemma.csv
src/tei2html --by lemma corpus/aratus.xml expectancy.lemma.csv > aratus.lemma.html
```

![A screenshot of tei2html output, showing the beginning of the Phaenomena, with words shaded according to lemma expectancy on a diverging scale.](https://github.com/sasansom/sedes/assets/53617134/4ce75cc2-c9d2-4d94-80fb-f21f3e0d0397)

You can also used the generalized expectancy to get a quick table of, e.g., *sedes* counts. (The presence of *sedes* 7.5 in the output is a bug in one of the databases somewhere.)

```
src/expectancy --by sedes corpus/*.csv
```

|sedes|<var>x</var>|<var>z</var>|
|---|--:|:---|
|1|72994|+1.87274522909726|
|2|26285|−0.755453961677871|
|2.5|21265|−1.03791686899105|
|3|39575|−0.00765873494637391|
|4|45360|+0.317848818600783|
|4.5|9899|−1.6774534037563|
|5|14438|−1.42205516943468|
|6|28321|−0.640893308432925|
|6.5|51473|+0.661812115892705|
|7|16850|−1.28633793189696|
|7.5|1|−2.23438923176144|
|8|32804|−0.38864605475066|
|8.5|2520|−2.0926513705021|
|9|43491|+0.212684839762471|
|10|20505|−1.08068017766794|
|10.5|35000|−0.265082599679|
|11|25890|−0.777679628687573|
|12|2710|−2.08196054333288|

Or you can use it to get a count of how many times each literal word appears:

```
src/expectancy --by word corpus/*.csv | sort -n -k 2 -t, | head
```

|word|<var>x</var>|<var>z</var>|
|---|--:|:--|
|καὶ|14219|+3.9393092791801|
|δ’|13150|+3.61544345859396|
|δὲ|8587|+2.2330302319012|
|τε|4530|+1.0039155133624|
|μὲν|3221|+0.607338937920626|
|ἐν|2787|+0.475853656223353|
|οἱ|2513|+0.392842211096503|
|δέ|2488|+0.385268174132374|
|γὰρ|2224|+0.305286343791176|
|τ’|1895|+0.205612017343243|

Earlier I said you can compute expectancy over almost any of the variables output by tei2csv. The exception is the "work" column. Actually, you can run the expectancy program with a `--by` specification involving `work` without problem. The problem is in tei2html, which as currently written, does not know what work it is processing. (Unlike tei2csv, which accepts a work ID on the command line.)

Closes #71.